### PR TITLE
Cart endpoint changes and fixes

### DIFF
--- a/src/shopify/base.py
+++ b/src/shopify/base.py
@@ -79,11 +79,12 @@ class API(
         kwargs = None
     ):
         cookie_l = []
-        if hasattr(self, "session_id"):
-            cookie_l.append("_session_id=%s" % self.session_id)
-        if hasattr(self, "cart"): cookie_l.append("cart=%s" % self.cart)
-        cookie = ";".join(cookie_l)
-        if not cookie: return
+        if "Storefront-Digest" in headers:
+            cookie_l.append("storefront_digest=%s" % headers["Storefront-Digest"])
+        if "Cart" in headers: 
+            cookie_l.append("cart=%s" % headers["Cart"])
+
+        cookie = "".join(cookie_l)
         headers["Cookie"] = cookie
 
     def get_many(self, url, key = None, **kwargs):

--- a/src/shopify/base.py
+++ b/src/shopify/base.py
@@ -78,15 +78,26 @@ class API(
         mime = None,
         kwargs = None
     ):
+        if not "kwargs" in kwargs: return
+
+        args = kwargs["kwargs"]
+        
         cookie_l = []
+        shopify_domain = None
+        
         # Each cookie must contain the token, path and domain, ex: 2312312323; Path=/; Domain=.myshop.myshopify.com; Secure;
-        if "Storefront-Digest" in headers:
-            cookie_l.append("storefront_digest=%s" % headers["Storefront-Digest"])
-        if "Cart" in headers: 
-            cookie_l.append("cart=%s" % headers["Cart"])
+        if "shopify_domain" in args:
+            shopify_domain = args["shopify_domain"]
+        if "storefront_digest" in args:
+            storefront_digest_cookie = "storefront_digest=%s; Path=/; Domain=%s; Secure;" % (args["storefront_digest"], shopify_domain)
+            cookie_l.append(storefront_digest_cookie)
+        if "cart" in args: 
+            cart_cookie = "cart=%s; Path=/; Domain=%s; Secure;" % (args["cart"], shopify_domain)
+            cookie_l.append(cart_cookie)
 
         cookie = "".join(cookie_l)
         headers["Cookie"] = cookie
+        kwargs = None
 
     def get_many(self, url, key = None, **kwargs):
             page = 1

--- a/src/shopify/base.py
+++ b/src/shopify/base.py
@@ -79,6 +79,7 @@ class API(
         kwargs = None
     ):
         cookie_l = []
+        # Each cookie must contain the token, path and domain, ex: 2312312323; Path=/; Domain=.myshop.myshopify.com; Secure;
         if "Storefront-Digest" in headers:
             cookie_l.append("storefront_digest=%s" % headers["Storefront-Digest"])
         if "Cart" in headers: 
@@ -109,4 +110,4 @@ class API(
         self.base_url = "https://%s:%s@%s/" % (
             self.api_key, self.password, self.store_url
         )
-        self.website_url = "http://%s/" % (self.website_url or self.store_url)
+        self.website_url = "https://%s/" % (self.website_url or self.store_url)

--- a/src/shopify/cart.py
+++ b/src/shopify/cart.py
@@ -40,10 +40,9 @@ __license__ = "Apache License, Version 2.0"
 import appier
 class CartAPI(object):
 
-    def get_cart(self):
+    def get_cart(self, headers={}):
         url = self.website_url + "cart.js"
-        contents, file = self.get(url, handle = True)
-        self._handle_cookie(file)
+        contents, file = self.get(url, headers=headers, handle=True)
         return contents
 
     def clear_cart(self):

--- a/src/shopify/cart.py
+++ b/src/shopify/cart.py
@@ -40,17 +40,17 @@ __license__ = "Apache License, Version 2.0"
 import appier
 class CartAPI(object):
 
-    def get_cart(self, headers={}):
+    def get_cart(self, params={}):
         url = self.website_url + "cart.js"
-        contents, file = self.get(url, headers=headers, handle=True)
+        contents, file = self.get(url, kwargs=params, handle=True)
         return contents
 
-    def clear_cart(self, headers={}):
+    def clear_cart(self, params={}):
         url = self.website_url + "cart/clear.js"
-        contents, file = self.get(url, headers=headers, handle = True)
+        contents, file = self.get(url, kwargs=params, handle = True)
         return contents
 
-    def add_cart(self, id, quantity=1, properties={}, headers={}):
+    def add_cart(self, id, quantity=1, properties={}, params={}):
         url = self.website_url + "cart/add.js"
         data_j = {}
         data_j["items"] = [
@@ -64,7 +64,7 @@ class CartAPI(object):
         contents, file = self.post(
             url,
             data_j=data_j,
-            headers=headers,
+            kwargs=params,
             handle = True
         )
         return contents

--- a/src/shopify/cart.py
+++ b/src/shopify/cart.py
@@ -42,12 +42,12 @@ class CartAPI(object):
 
     def get_cart(self, params={}):
         url = self.website_url + "cart.js"
-        contents, file = self.get(url, kwargs=params, handle=True)
+        contents = self.get(url, kwargs=params, handle=True)
         return contents
 
     def clear_cart(self, params={}):
         url = self.website_url + "cart/clear.js"
-        contents, file = self.get(url, kwargs=params, handle = True)
+        contents = self.get(url, kwargs=params, handle = True)
         return contents
 
     def add_cart(self, id, quantity=1, properties={}, params={}):
@@ -61,7 +61,7 @@ class CartAPI(object):
             )
         ]
 
-        contents, file = self.post(
+        contents = self.post(
             url,
             data_j=data_j,
             kwargs=params,

--- a/src/shopify/cart.py
+++ b/src/shopify/cart.py
@@ -38,7 +38,6 @@ __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
 import appier
-
 class CartAPI(object):
 
     def get_cart(self):
@@ -53,7 +52,7 @@ class CartAPI(object):
         self._handle_cookie(file)
         return contents
 
-    def add_cart(self, id, quantity = 1, properties={}):
+    def add_cart(self, id, quantity=1, properties={}, headers={}):
         url = self.website_url + "cart/add.js"
         data_j = {}
         data_j["items"] = [
@@ -67,9 +66,9 @@ class CartAPI(object):
         contents, file = self.post(
             url,
             data_j=data_j,
+            headers=headers,
             handle = True
         )
-        self._handle_cookie(file)
         return contents
 
     def _handle_cookie(self, file):

--- a/src/shopify/cart.py
+++ b/src/shopify/cart.py
@@ -53,14 +53,20 @@ class CartAPI(object):
         self._handle_cookie(file)
         return contents
 
-    def add_cart(self, id, quantity = 1):
+    def add_cart(self, id, quantity = 1, properties={}):
         url = self.website_url + "cart/add.js"
+        data_j = {}
+        data_j["items"] = [
+            dict(
+                id=id,
+                quantity=quantity,
+                properties=properties
+            )
+        ]
+
         contents, file = self.post(
             url,
-            data_j = dict(
-                id = id,
-                quantity = quantity
-            ),
+            data_j=data_j,
             handle = True
         )
         self._handle_cookie(file)

--- a/src/shopify/cart.py
+++ b/src/shopify/cart.py
@@ -45,10 +45,9 @@ class CartAPI(object):
         contents, file = self.get(url, headers=headers, handle=True)
         return contents
 
-    def clear_cart(self):
+    def clear_cart(self, headers={}):
         url = self.website_url + "cart/clear.js"
-        contents, file = self.post(url, handle = True)
-        self._handle_cookie(file)
+        contents, file = self.get(url, headers=headers, handle = True)
         return contents
 
     def add_cart(self, id, quantity=1, properties={}, headers={}):
@@ -69,13 +68,3 @@ class CartAPI(object):
             handle = True
         )
         return contents
-
-    def _handle_cookie(self, file):
-        headers = file.info()
-        cookie = headers.get("Set-Cookie", None)
-        if not cookie: return
-        cookie_m = appier.parse_cookie(cookie)
-        session_id = cookie_m.get("_session_id", None)
-        cart = cookie_m.get("cart", None)
-        if session_id: self.session_id = session_id
-        if cart: self.cart = cart


### PR DESCRIPTION
**This PR aims to fix the cart operations available by this API.**

Changes:
 - Shopify API now uses the `cart` and the `storefront_digest` cookies that are needed for the cart operations to work. In order for the cookies to be handled correctly by the API, their values need to be passed as parameteres in the url, as the correct domain of the cookies. The paramenter for the cookies domain is `shopify_domain`.
 - Add cart now supports `properties` field.
 - Removed `_handle_cookie` method as it wasn't working properly.