### PR TITLE
Add method to handle order fulfillment

### DIFF
--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -83,3 +83,12 @@ class OrderAPI(object):
                 email = email
             )
         )
+
+    def fulfill_order(self, id, location_id, **kwargs):
+        fulfillment = dict(kwargs)
+        fulfillment["location_id"] = location_id
+        url = self.base_url + "admin/orders/%d/fulfillments.json" % id
+        self.post(
+            url,
+            data_j = dict(fulfillment = fulfillment)
+        )


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/products/issues/44 |
| Dependencies | -- |
| Decisions | Create method `fulfill_order` that allows to update the fulfillment state in a shopify order |
| Reference | https://shopify.dev/api/admin/rest/reference/shipping-and-fulfillment/fulfillment#create-2021-07 |