### PR TITLE
Add method to handle orders metafields creation and listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Endpoint for creating and listing order metafields
 
 ### Changed
 

--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -92,3 +92,23 @@ class OrderAPI(object):
             url,
             data_j = dict(fulfillment = fulfillment)
         )
+
+    def metafields_order(self, id, *args, **kwargs):
+        url = self.base_url + "admin/orders/%d/metafields.json" % id
+        contents = self.get(url, **kwargs)
+        return contents["metafields"]
+
+    def create_metafield_order(self, id, key, value, value_type = "string", namespace = "global"):
+        url = self.base_url + "admin/orders/%d/metafields.json" % id
+        contents = self.post(
+            url,
+            data_j = dict(
+                metafield = dict(
+                    namespace = namespace,
+                    key = key,
+                    value = value,
+                    value_type = value_type
+                )
+            )
+        )
+        return contents["metafield"]


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/products/issues/44 |
| Dependencies | -- |
| Decisions | • Create method `metafields_order` that allows to list the shopify order metafields<br> • Create method `create_metafield_order` that allows to add a metafield entry to the shopify order metafields |
| Reference | https://shopify.dev/api/admin/rest/reference/metafield |