### PR TITLE
Add get_orders_count + improve shopify list_orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `get_orders_count` that returns the number of existing Shopify orders
 
 ### Changed
 
-*
+* Improve `list_orders` by making return all the existing Shopify orders
 
 ### Fixed
 

--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -50,12 +50,14 @@ class OrderAPI(object):
         last_id = None
         orders_count = limit
 
+        # if "all" flag is set to true then set the "limit" to the maximum
+        # allowed value (250) and set "order_count" with the total number
+        # of existing orders
         if all:
             limit = 250
-            last_id = 0
             orders_count = self.get_orders_count()
 
-        # keep fetching orders until it reached the wanted limit
+        # keep fetching orders until there isn't any more orders to fetch
         while orders_count > 0:
             contents = self.get(
                 url,

--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -39,10 +39,35 @@ __license__ = "Apache License, Version 2.0"
 
 class OrderAPI(object):
 
-    def list_orders(self, *args, **kwargs):
-        url = self.base_url + "admin/orders.json"
+    def get_orders_count(self, *args, **kwargs):
+        url = self.base_url + "admin/orders/count.json"
         contents = self.get(url, **kwargs)
-        return contents["orders"]
+        return contents["count"]
+
+    def list_orders(self, all = True, limit = 50, **kwargs):
+        url = self.base_url + "admin/orders.json"
+        orders = []
+        last_id = None
+        orders_count = limit
+
+        if all:
+            limit = 250
+            last_id = 0
+            orders_count = self.get_orders_count()
+
+        # keep fetching orders until it reached the wanted limit
+        while orders_count > 0:
+            contents = self.get(
+                url,
+                limit = limit,
+                since_id = last_id,
+                **kwargs
+            )
+            orders.extend(contents["orders"])
+            last_id = orders[-1]["id"]
+            orders_count -= limit
+
+        return orders
 
     def get_order(self, id):
         url = self.base_url + "admin/orders/%d.json" % id

--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -64,7 +64,10 @@ class OrderAPI(object):
                 **kwargs
             )
             orders.extend(contents["orders"])
-            last_id = orders[-1]["id"]
+            try:
+                last_id = orders[-1]["id"]
+            except:
+                return []
             orders_count -= limit
 
         return orders


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Need to list all Shopify orders |
| Dependencies | -- |
| Decisions | Add `get_orders_count` that returns the number of existing Shopify orders<br> Improve `list_orders` to get all of the shopify orders |