### PR TITLE
#19: metafield type over metafield value_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Renamed metafield `value_type` as `type` due to Shopify deprecation
 
 ## [0.6.4] - 2021-12-03
 

--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -115,7 +115,7 @@ class OrderAPI(object):
         contents = self.get(url, **kwargs)
         return contents["metafields"]
 
-    def create_metafield_order(self, id, key, value, value_type = "string", namespace = "global"):
+    def create_metafield_order(self, id, key, value, type = "string", namespace = "global"):
         url = self.base_url + "admin/orders/%d/metafields.json" % id
         contents = self.post(
             url,
@@ -124,7 +124,7 @@ class OrderAPI(object):
                     namespace = namespace,
                     key = key,
                     value = value,
-                    value_type = value_type
+                    type = type
                 )
             )
         )

--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -115,7 +115,9 @@ class OrderAPI(object):
         contents = self.get(url, **kwargs)
         return contents["metafields"]
 
-    def create_metafield_order(self, id, key, value, type = "string", namespace = "global"):
+    def create_metafield_order(self, id, key, value, type = None, value_type = None, namespace = "global"):
+        type = type or value_type or "string"
+
         url = self.base_url + "admin/orders/%d/metafields.json" % id
         contents = self.post(
             url,

--- a/src/shopify/product.py
+++ b/src/shopify/product.py
@@ -94,7 +94,9 @@ class ProductAPI(object):
         contents = self.get(url, **kwargs)
         return contents["metafields"]
 
-    def create_metafield_product(self, id, key, value, type = "string", namespace = "global"):
+    def create_metafield_product(self, id, key, value, type = None, value_type = None, namespace = "global"):
+        type = type or value_type or "string"
+
         url = self.base_url + "admin/products/%d/metafields.json" % id
         contents = self.post(
             url,

--- a/src/shopify/product.py
+++ b/src/shopify/product.py
@@ -94,7 +94,7 @@ class ProductAPI(object):
         contents = self.get(url, **kwargs)
         return contents["metafields"]
 
-    def create_metafield_product(self, id, key, value, value_type = "string", namespace = "global"):
+    def create_metafield_product(self, id, key, value, type = "string", namespace = "global"):
         url = self.base_url + "admin/products/%d/metafields.json" % id
         contents = self.post(
             url,
@@ -103,7 +103,7 @@ class ProductAPI(object):
                     namespace = namespace,
                     key = key,
                     value = value,
-                    value_type = value_type
+                    type = type
                 )
             )
         )


### PR DESCRIPTION
@joamag 

Refers to: https://github.com/hivesolutions/shopify-api/issues/19

In this solution we accept both `type` and `value_type` from clients of this API. However, we set only `type` to be compliant with Shopify's new API version. Initially thought on setting both type and value_type but seems like it will still throw a deprecation warning for the newest version.