### PR TITLE
Support for versioned admin endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add support for versioned admin endpoints
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ API client for the [Shopify](https://www.shopify.com) service.
 
 | Name                     | Type  | Default | Description                                                                                                |
 | ------------------------ | ----- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| **SHOPIFY_API_VERSION**  | `str` | `None`  | The Shopify API version to be used. Example: `2023-01`.                                                    |
 | **SHOPIFY_API_KEY**      | `str` | `None`  | The username/key to be used in the authentication with the Shopify API.                                    |
 | **SHOPIFY_PASSWORD**     | `str` | `None`  | The password to be used in the authentication with the Shopify API.                                        |
 | **SHOPIFY_SECRET**       | `str` | `None`  | The shared secret to be used for message validation with the Shopify API.                                  |

--- a/src/shopify/base.py
+++ b/src/shopify/base.py
@@ -188,6 +188,10 @@ class API(
             message = "Request signature is not valid",
             exception = appier.SecurityError
         )
+    
+    def _build_admin_url(self):
+        api_version_path = "api/%s/" % self.api_version if self.api_version else ""
+        return self.base_url + "admin/%s" % api_version_path
 
     def _build_url(self):
         if not self.api_key:
@@ -200,9 +204,7 @@ class API(
             self.api_key, self.password, self.store_url
         )
         self.website_url = "http://%s/" % (self.website_url or self.store_url)
-        
-        api_version_path = "api/%s/" % self.api_version if self.api_version else ""
-        self.admin_url = self.base_url + "admin/%s" % api_version_path
+        self.admin_url = self._build_admin_url()
 
 class OAuthAPI(appier.OAuth2API, API):
 
@@ -257,6 +259,7 @@ class OAuthAPI(appier.OAuth2API, API):
         if not self.store_url:
             raise appier.OperationalError(message = "No store URL provided")
         self.base_url = "https://%s/" % self.store_url
+        self.admin_url = self._build_admin_url()
 
     def _fetch_many(
         self, 

--- a/src/shopify/base.py
+++ b/src/shopify/base.py
@@ -200,7 +200,9 @@ class API(
             self.api_key, self.password, self.store_url
         )
         self.website_url = "http://%s/" % (self.website_url or self.store_url)
-        self.api_version_path = "api/%s" % (self.api_version or "") #################### 2023-01
+        
+        api_version_path = "api/%s/" % self.api_version if self.api_version else ""
+        self.admin_url = "%sadmin/%s" % (self.base_url, api_version_path)
 
 class OAuthAPI(appier.OAuth2API, API):
 

--- a/src/shopify/base.py
+++ b/src/shopify/base.py
@@ -85,11 +85,13 @@ class API(
 
     def __init__(self, *args, **kwargs):
         appier.API.__init__(self, *args, **kwargs)
+        self.api_version = appier.conf("SHOPIFY_API_VERSION", None)
         self.api_key = appier.conf("SHOPIFY_API_KEY", None)
         self.password = appier.conf("SHOPIFY_PASSWORD", None)
         self.secret = appier.conf("SHOPIFY_SECRET", None)
         self.store_url = appier.conf("SHOPIFY_STORE", None)
         self.website_url = appier.conf("SHOPIFY_WEBSITE", None)
+        self.api_version = kwargs.get("api_version", self.api_version)
         self.api_key = kwargs.get("api_key", self.api_key)
         self.password = kwargs.get("password", self.password)
         self.secret = kwargs.get("secret", self.secret)
@@ -198,6 +200,7 @@ class API(
             self.api_key, self.password, self.store_url
         )
         self.website_url = "http://%s/" % (self.website_url or self.store_url)
+        self.api_version_path = "api/%s" % (self.api_version or "") #################### 2023-01
 
 class OAuthAPI(appier.OAuth2API, API):
 

--- a/src/shopify/base.py
+++ b/src/shopify/base.py
@@ -202,7 +202,7 @@ class API(
         self.website_url = "http://%s/" % (self.website_url or self.store_url)
         
         api_version_path = "api/%s/" % self.api_version if self.api_version else ""
-        self.admin_url = "%sadmin/%s" % (self.base_url, api_version_path)
+        self.admin_url = self.base_url + "admin/%s" % api_version_path
 
 class OAuthAPI(appier.OAuth2API, API):
 

--- a/src/shopify/inventory_item.py
+++ b/src/shopify/inventory_item.py
@@ -40,16 +40,16 @@ __license__ = "Apache License, Version 2.0"
 class InventoryItemAPI(object):
 
     def list_inventory_items(self, *args, **kwargs):
-        url = self.base_url + "admin/inventory_items.json"
+        url = self.admin_url + "inventory_items.json"
         contents = self.get(url, **kwargs)
         return contents["inventory_items"]
 
     def get_inventory_item(self, id):
-        url = self.base_url + "admin/inventory_items/%d.json" % id
+        url = self.admin_url + "inventory_items/%d.json" % id
         contents = self.get(url)
         return contents["inventory_item"]
 
     def update_inventory_item(self, id, inventory_item):
-        url = self.base_url + "admin/inventory_items/%d.json" % id
+        url = self.admin_url + "inventory_items/%d.json" % id
         contents = self.put(url, data_j = dict(inventory_item = inventory_item))
         return contents["inventory_item"]

--- a/src/shopify/location.py
+++ b/src/shopify/location.py
@@ -40,6 +40,6 @@ __license__ = "Apache License, Version 2.0"
 class LocationAPI(object):
 
     def list_locations(self, *args, **kwargs):
-        url = self.base_url + "admin/locations.json"
+        url = self.admin_url + "locations.json"
         contents = self.get(url, **kwargs)
         return contents["locations"]

--- a/src/shopify/order.py
+++ b/src/shopify/order.py
@@ -40,12 +40,12 @@ __license__ = "Apache License, Version 2.0"
 class OrderAPI(object):
 
     def list_orders(self, *args, **kwargs):
-        url = self.base_url + "admin/orders.json"
+        url = self.admin_url + "orders.json"
         contents = self.get(url, **kwargs)
         return contents["orders"]
 
     def list_orders_a(self, limit = 50, all = True, **kwargs):
-        url = self.base_url + "admin/orders.json"
+        url = self.admin_url + "orders.json"
         orders = self._fetch_many(
             url,
             item_name = "orders",
@@ -57,31 +57,31 @@ class OrderAPI(object):
         return orders
 
     def get_order(self, id):
-        url = self.base_url + "admin/orders/%d.json" % id
+        url = self.admin_url + "orders/%d.json" % id
         contents = self.get(url)
         return contents["order"]
 
     def count_orders(self, *args, **kwargs):
-        url = self.base_url + "admin/orders/count.json"
+        url = self.admin_url + "orders/count.json"
         contents = self.get(url, **kwargs)
         return contents["count"]
 
     def transactions_order(self, id):
-        url = self.base_url + "admin/orders/%d/transactions.json" % id
+        url = self.admin_url + "orders/%d/transactions.json" % id
         contents = self.get(url)
         return contents["transactions"]
 
     def update_order(self, id, **kwargs):
         order = dict(kwargs)
         order["id"] = str(id)
-        url = self.base_url + "admin/orders/%d.json" % id
+        url = self.admin_url + "orders/%d.json" % id
         self.put(
             url,
             data_j = dict(order = order)
         )
 
     def pay_order(self, id):
-        url = self.base_url + "admin/orders/%d/transactions.json" % id
+        url = self.admin_url + "orders/%d/transactions.json" % id
         self.post(
             url,
             data_j = dict(
@@ -92,7 +92,7 @@ class OrderAPI(object):
         )
 
     def cancel_order(self, id, restock = True, email = False):
-        url = self.base_url + "admin/orders/%d/cancel.json" % id
+        url = self.admin_url + "orders/%d/cancel.json" % id
         self.post(
             url,
             data_j = dict(
@@ -104,20 +104,20 @@ class OrderAPI(object):
     def fulfill_order(self, id, location_id, **kwargs):
         fulfillment = dict(kwargs)
         fulfillment["location_id"] = location_id
-        url = self.base_url + "admin/orders/%d/fulfillments.json" % id
+        url = self.admin_url + "orders/%d/fulfillments.json" % id
         self.post(
             url,
             data_j = dict(fulfillment = fulfillment)
         )
 
     def metafields_order(self, id, *args, **kwargs):
-        url = self.base_url + "admin/orders/%d/metafields.json" % id
+        url = self.admin_url + "orders/%d/metafields.json" % id
         contents = self.get(url, **kwargs)
         return contents["metafields"]
 
     def create_metafield_order(self, id, key, value, type = None, value_type = None, namespace = "global"):
         type = type or value_type or "string"
-        url = self.base_url + "admin/orders/%d/metafields.json" % id
+        url = self.admin_url + "orders/%d/metafields.json" % id
         contents = self.post(
             url,
             data_j = dict(

--- a/src/shopify/product.py
+++ b/src/shopify/product.py
@@ -40,12 +40,12 @@ __license__ = "Apache License, Version 2.0"
 class ProductAPI(object):
 
     def list_products(self, *args, **kwargs):
-        url = self.base_url + "admin/%s/products.json" % self.api_version_path
+        url = self.admin_url + "products.json"
         contents = self.get(url, **kwargs)
         return contents["products"]
 
     def many_products(self, *args, **kwargs):
-        url = self.base_url + "admin/%s/products.json" % self.api_version_path
+        url = self.admin_url + "products.json"
         contents = self.get_many(
             url,
             key = "products",
@@ -54,12 +54,12 @@ class ProductAPI(object):
         return contents["products"]
 
     def count_products(self, *args, **kwargs):
-        url = self.base_url + "admin/%s/products/count.json" % self.api_version_path
+        url = self.admin_url + "products/count.json"
         contents = self.get(url, **kwargs)
         return contents["count"]
 
     def create_product(self, product):
-        url = self.base_url + "admin/%s/products.json" % self.api_version_path
+        url = self.admin_url + "products.json"
         contents = self.post(
             url,
             data_j = dict(product = product)
@@ -67,36 +67,36 @@ class ProductAPI(object):
         return contents["product"]
 
     def get_product(self, id):
-        url = self.base_url + "admin/%s/products/%d.json" % (self.api_version_path, id)
+        url = self.admin_url + "products/%d.json" % id
         contents = self.get(url)
         return contents["product"]
 
     def delete_product(self, id):
-        url = self.base_url + "admin/%s/products/%d.json" % (self.api_version_path, id)
+        url = self.admin_url + "products/%d.json" % id
         self.delete(url)
 
     def images_product(self, id, *args, **kwargs):
-        url = self.base_url + "admin/%s/products/%d/images.json" % (self.api_version_path, id)
+        url = self.admin_url + "products/%d/images.json" % id
         contents = self.get(url, **kwargs)
         return contents["images"]
 
     def create_image_product(self, id, image):
-        url = self.base_url + "admin/%s/products/%d/images.json" % (self.api_version_path, id)
+        url = self.admin_url + "products/%d/images.json" % id
         contents = self.post(url, data_j = dict(image = image))
         return contents["image"]
 
     def delete_image_product(self, id, image_id):
-        url = self.base_url + "admin/%s/products/%d/images/%d.json" % (self.api_version_path, id, image_id)
+        url = self.admin_url + "products/%d/images/%d.json" % (id, image_id)
         self.delete(url)
 
     def metafields_product(self, id, *args, **kwargs):
-        url = self.base_url + "admin/%s/products/%d/metafields.json" % (self.api_version_path, id)
+        url = self.admin_url + "products/%d/metafields.json" % id
         contents = self.get(url, **kwargs)
         return contents["metafields"]
 
     def create_metafield_product(self, id, key, value, type = None, value_type = None, namespace = "global"):
         type = type or value_type or "string"
-        url = self.base_url + "admin/%s/products/%d/metafields.json" % (self.api_version_path, id)
+        url = self.admin_url + "products/%d/metafields.json" % id
         contents = self.post(
             url,
             data_j = dict(

--- a/src/shopify/product.py
+++ b/src/shopify/product.py
@@ -40,12 +40,12 @@ __license__ = "Apache License, Version 2.0"
 class ProductAPI(object):
 
     def list_products(self, *args, **kwargs):
-        url = self.base_url + "admin/products.json"
+        url = self.base_url + "admin/%s/products.json" % self.api_version_path
         contents = self.get(url, **kwargs)
         return contents["products"]
 
     def many_products(self, *args, **kwargs):
-        url = self.base_url + "admin/products.json"
+        url = self.base_url + "admin/%s/products.json" % self.api_version_path
         contents = self.get_many(
             url,
             key = "products",
@@ -54,12 +54,12 @@ class ProductAPI(object):
         return contents["products"]
 
     def count_products(self, *args, **kwargs):
-        url = self.base_url + "admin/products/count.json"
+        url = self.base_url + "admin/%s/products/count.json" % self.api_version_path
         contents = self.get(url, **kwargs)
         return contents["count"]
 
     def create_product(self, product):
-        url = self.base_url + "admin/products.json"
+        url = self.base_url + "admin/%s/products.json" % self.api_version_path
         contents = self.post(
             url,
             data_j = dict(product = product)
@@ -67,36 +67,36 @@ class ProductAPI(object):
         return contents["product"]
 
     def get_product(self, id):
-        url = self.base_url + "admin/products/%d.json" % id
+        url = self.base_url + "admin/%s/products/%d.json" % (self.api_version_path, id)
         contents = self.get(url)
         return contents["product"]
 
     def delete_product(self, id):
-        url = self.base_url + "admin/products/%d.json" % id
+        url = self.base_url + "admin/%s/products/%d.json" % (self.api_version_path, id)
         self.delete(url)
 
     def images_product(self, id, *args, **kwargs):
-        url = self.base_url + "admin/products/%d/images.json" % id
+        url = self.base_url + "admin/%s/products/%d/images.json" % (self.api_version_path, id)
         contents = self.get(url, **kwargs)
         return contents["images"]
 
     def create_image_product(self, id, image):
-        url = self.base_url + "admin/products/%d/images.json" % id
+        url = self.base_url + "admin/%s/products/%d/images.json" % (self.api_version_path, id)
         contents = self.post(url, data_j = dict(image = image))
         return contents["image"]
 
     def delete_image_product(self, id, image_id):
-        url = self.base_url + "admin/products/%d/images/%d.json" % (id, image_id)
+        url = self.base_url + "admin/%s/products/%d/images/%d.json" % (self.api_version_path, id, image_id)
         self.delete(url)
 
     def metafields_product(self, id, *args, **kwargs):
-        url = self.base_url + "admin/products/%d/metafields.json" % id
+        url = self.base_url + "admin/%s/products/%d/metafields.json" % (self.api_version_path, id)
         contents = self.get(url, **kwargs)
         return contents["metafields"]
 
     def create_metafield_product(self, id, key, value, type = None, value_type = None, namespace = "global"):
         type = type or value_type or "string"
-        url = self.base_url + "admin/products/%d/metafields.json" % id
+        url = self.base_url + "admin/%s/products/%d/metafields.json" % (self.api_version_path, id)
         contents = self.post(
             url,
             data_j = dict(

--- a/src/shopify/shop.py
+++ b/src/shopify/shop.py
@@ -40,6 +40,6 @@ __license__ = "Apache License, Version 2.0"
 class ShopAPI(object):
 
     def get_shop(self, *args, **kwargs):
-        url = self.base_url + "admin/shop.json"
+        url = self.admin_url + "shop.json"
         contents = self.get(url, **kwargs)
         return contents["shop"]

--- a/src/shopify/smart_collection.py
+++ b/src/shopify/smart_collection.py
@@ -40,12 +40,12 @@ __license__ = "Apache License, Version 2.0"
 class SmartCollectionAPI(object):
 
     def list_smart_collections(self, *args, **kwargs):
-        url = self.base_url + "admin/smart_collections.json"
+        url = self.admin_url + "smart_collections.json"
         contents = self.get(url, **kwargs)
         return contents["smart_collections"]
 
     def many_smart_collections(self, *args, **kwargs):
-        url = self.base_url + "admin/smart_collections.json"
+        url = self.admin_url + "smart_collections.json"
         contents = self.get_many(
             url,
             key = "smart_collections",
@@ -54,20 +54,20 @@ class SmartCollectionAPI(object):
         return contents["smart_collections"]
 
     def create_smart_collection(self, smart_collection):
-        url = self.base_url + "admin/smart_collections.json"
+        url = self.admin_url + "smart_collections.json"
         contents = self.post(url, data_j = dict(smart_collection = smart_collection))
         return contents["smart_collection"]
 
     def get_smart_collection(self, id):
-        url = self.base_url + "admin/smart_collections/%d.json" % id
+        url = self.admin_url + "smart_collections/%d.json" % id
         contents = self.get(url)
         return contents["smart_collection"]
 
     def update_smart_collection(self, id, smart_collection):
-        url = self.base_url + "admin/smart_collections/%d.json" % id
+        url = self.admin_url + "smart_collections/%d.json" % id
         contents = self.put(url, data_j = dict(smart_collection = smart_collection))
         return contents["smart_collection"]
 
     def delete_smart_collection(self, id):
-        url = self.base_url + "admin/smart_collections/%d.json" % id
+        url = self.admin_url + "smart_collections/%d.json" % id
         self.delete(url)

--- a/src/shopify/webhook.py
+++ b/src/shopify/webhook.py
@@ -40,25 +40,25 @@ __license__ = "Apache License, Version 2.0"
 class WebhookAPI(object):
 
     def list_webhooks(self, *args, **kwargs):
-        url = self.base_url + "admin/webhooks.json"
+        url = self.admin_url + "webhooks.json"
         contents = self.get(url, **kwargs)
         return contents["webhooks"]
 
     def create_webhook(self, webhook):
-        url = self.base_url + "admin/webhooks.json"
+        url = self.admin_url + "webhooks.json"
         contents = self.post(url, data_j = dict(webhook = webhook))
         return contents["webhook"]
 
     def get_webhook(self, id):
-        url = self.base_url + "admin/webhooks/%d.json" % id
+        url = self.admin_url + "webhooks/%d.json" % id
         contents = self.get(url)
         return contents["webhook"]
 
     def update_webhook(self, id, webhook):
-        url = self.base_url + "admin/webhooks/%d.json" % id
+        url = self.admin_url + "webhooks/%d.json" % id
         contents = self.put(url, data_j = dict(webhook = webhook))
         return contents["webhook"]
 
     def delete_webhook(self, id):
-        url = self.base_url + "admin/webhooks/%d.json" % id
+        url = self.admin_url + "webhooks/%d.json" % id
         self.delete(url)


### PR DESCRIPTION
There is a need to specify the API version in order to properly update and handle deprecated code. This PR adds support for versionated admin API by allowing to use `SHOPIFY_API_VERSION` to specify the API version to be used.

References:
https://shopify.dev/api/admin-rest/2023-01/resources/inventoryitem
https://shopify.dev/api/admin-rest/2023-01/resources/location
https://shopify.dev/api/admin-rest/2023-01/resources/order
https://shopify.dev/api/admin-rest/2023-01/resources/product
https://shopify.dev/api/admin-rest/2023-01/resources/shop
https://shopify.dev/api/admin-rest/2023-01/resources/smartcollection
https://shopify.dev/api/admin-rest/2023-01/resources/webhook